### PR TITLE
issues

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -1,0 +1,245 @@
+# API設計書
+
+麻雀リーグ管理アプリのAPI設計
+
+---
+
+## 基本仕様
+
+### 認証
+- **Supabase Auth**を使用
+- フロントエンドで直接 Supabase Auth を利用
+- APIは認証済みユーザー情報（JWT）を受け取る
+- 🔒マークは認証必須のエンドポイント
+
+### エラーレスポンス
+
+すべてのエラーは以下の形式で返す：
+
+```json
+{
+  "error": "ValidationError",
+  "message": "nameは1-20文字で入力してください",
+  "statusCode": 400
+}
+```
+
+**主なステータスコード:**
+- `400` - バリデーションエラー
+- `401` - 認証エラー
+- `403` - 権限エラー
+- `404` - リソースが見つからない
+- `500` - サーバーエラー
+
+---
+
+## リーグ管理API
+
+### `POST /api/leagues` 🔒
+
+新規リーグを作成
+
+**リクエスト:**
+```typescript
+{
+  name: string,              // 必須、1-20文字
+  description?: string,      // 任意
+  players?: Array<{          // 任意（推奨: 16人）
+    name: string             // 必須、1-20文字
+  }>
+}
+```
+
+**例:**
+```json
+{
+  "name": "2025年春リーグ",
+  "description": "毎週金曜日開催",
+  "players": [
+    { "name": "山田太郎" },
+    { "name": "鈴木次郎" },
+    { "name": "佐藤三郎" },
+    { "name": "田中四郎" }
+  ]
+}
+```
+
+**レスポンス（201 Created）:**
+```typescript
+{
+  id: string,
+  name: string,
+  description: string | null,
+  status: 'active' | 'completed' | 'deleted',
+  created_by: string,
+  created_at: string,        // ISO 8601形式
+  updated_at: string,
+  players: Array<{
+    id: string,
+    name: string,
+    user_id: string | null,
+    created_at: string
+  }>
+}
+```
+
+**内部処理:**
+- 作成者を自動的に `league_members` に追加（role: admin）
+
+---
+
+### `GET /api/leagues` 🔒
+
+自分が参加しているリーグ一覧を取得
+
+**リクエスト:** なし
+
+**レスポンス（200 OK）:**
+```typescript
+{
+  leagues: Array<{
+    id: string,
+    name: string,
+    description: string | null,
+    status: 'active' | 'completed' | 'deleted',
+    created_by: string,
+    created_at: string,
+    updated_at: string
+  }>
+}
+```
+
+---
+
+### `GET /api/leagues/:id` 🔒
+
+リーグ詳細を取得
+
+**リクエスト:** なし
+
+**レスポンス（200 OK）:**
+```typescript
+{
+  id: string,
+  name: string,
+  description: string | null,
+  status: 'active' | 'completed' | 'deleted',
+  created_by: string,
+  created_at: string,
+  updated_at: string,
+  players: Array<{
+    id: string,
+    name: string,
+    user_id: string | null
+  }>,
+  members: Array<{
+    user_id: string,
+    role: 'admin' | 'scorer' | 'viewer'
+  }>
+}
+```
+
+---
+
+### `PATCH /api/leagues/:id` 🔒
+
+リーグ情報を更新
+
+**リクエスト:**
+```typescript
+{
+  name?: string,           // 1-20文字
+  description?: string
+}
+```
+
+**レスポンス（200 OK）:**
+```typescript
+{
+  id: string,
+  name: string,
+  description: string | null,
+  status: 'active' | 'completed' | 'deleted',
+  updated_at: string
+}
+```
+
+---
+
+### `DELETE /api/leagues/:id` 🔒
+
+リーグを削除（論理削除）
+
+ステータスを `deleted` に変更する
+
+**リクエスト:** なし
+
+**レスポンス（204 No Content）**
+
+---
+
+### `PATCH /api/leagues/:id/status` 🔒
+
+リーグステータスを変更
+
+**リクエスト:**
+```typescript
+{
+  status: 'active' | 'completed' | 'deleted'
+}
+```
+
+**レスポンス（200 OK）:**
+```typescript
+{
+  id: string,
+  status: 'active' | 'completed' | 'deleted',
+  updated_at: string
+}
+```
+
+---
+
+## 今後実装予定のAPI
+
+### プレイヤー管理
+- `POST /api/leagues/:id/players` - プレイヤー追加
+- `PATCH /api/leagues/:id/players/:playerId` - プレイヤー更新
+- `DELETE /api/leagues/:id/players/:playerId` - プレイヤー削除
+
+### メンバー管理
+- `POST /api/leagues/:id/members` - メンバー招待
+- `PATCH /api/leagues/:id/members/:userId` - 権限変更
+- `DELETE /api/leagues/:id/members/:userId` - メンバー削除
+
+### 節管理
+- 対局の単位（session）のCRUD
+
+### 卓・点数管理
+- 卓（table）のCRUD
+- 点数入力・計算
+
+### ランキング
+- `GET /api/leagues/:id/ranking` - ランキング取得
+
+### プレイヤー紐づけリクエスト
+- ユーザーとプレイヤーの紐づけ申請
+
+---
+
+## 用語の整理
+
+### プレイヤー（players）
+- リーグで**麻雀を打つ人**（通常16人）
+- アプリのユーザーである必要はない
+- `user_id` は null でもOK（後で紐づけ可能）
+
+### メンバー（league_members）
+- リーグを**運営・管理するユーザー**
+- 必ずアプリのユーザー（`user_id` 必須）
+- 権限: `admin`, `scorer`, `viewer`
+
+---
+
+**作成日:** 2025-11-08
+**最終更新:** 2025-11-08

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -44,13 +44,18 @@
 {
   name: string,              // 必須、1-20文字
   description?: string,      // 任意
-  players?: Array<{          // 任意（推奨: 16人）
+  players: Array<{           // 必須、8人または16人
     name: string             // 必須、1-20文字
   }>
 }
 ```
 
-**例:**
+**バリデーション:**
+- `players` は必須
+- `players.length === 8 || players.length === 16`
+- それ以外は `400 Bad Request`
+
+**例（16人リーグ）:**
 ```json
 {
   "name": "2025年春リーグ",
@@ -59,7 +64,19 @@
     { "name": "山田太郎" },
     { "name": "鈴木次郎" },
     { "name": "佐藤三郎" },
-    { "name": "田中四郎" }
+    { "name": "田中四郎" },
+    { "name": "伊藤五郎" },
+    { "name": "渡辺六郎" },
+    { "name": "加藤七郎" },
+    { "name": "中村八郎" },
+    { "name": "小林九郎" },
+    { "name": "吉田十郎" },
+    { "name": "高橋一郎" },
+    { "name": "松本二郎" },
+    { "name": "木村三郎" },
+    { "name": "林四郎" },
+    { "name": "清水五郎" },
+    { "name": "森六郎" }
   ]
 }
 ```
@@ -200,12 +217,36 @@
 
 ---
 
-## 今後実装予定のAPI
+## プレイヤー管理API
 
-### プレイヤー管理
-- `POST /api/leagues/:id/players` - プレイヤー追加
-- `PATCH /api/leagues/:id/players/:playerId` - プレイヤー更新
-- `DELETE /api/leagues/:id/players/:playerId` - プレイヤー削除
+### `PATCH /api/leagues/:id/players/:playerId` 🔒
+
+プレイヤー名を更新（表記ゆれ修正用）
+
+**注意:**
+- プレイヤーの追加・削除は不可（リーグ作成時に8人または16人で確定）
+- 名前の編集のみ可能
+
+**リクエスト:**
+```typescript
+{
+  name: string  // 必須、1-20文字
+}
+```
+
+**レスポンス（200 OK）:**
+```typescript
+{
+  id: string,
+  name: string,
+  user_id: string | null,
+  updated_at: string
+}
+```
+
+---
+
+## 今後実装予定のAPI
 
 ### メンバー管理
 - `POST /api/leagues/:id/members` - メンバー招待
@@ -230,9 +271,11 @@
 ## 用語の整理
 
 ### プレイヤー（players）
-- リーグで**麻雀を打つ人**（通常16人）
+- リーグで**麻雀を打つ人**（8人または16人）
+- リーグ作成時に人数確定、途中での追加・削除は不可
 - アプリのユーザーである必要はない
 - `user_id` は null でもOK（後で紐づけ可能）
+- 名前の編集のみ可能（表記ゆれ修正用）
 
 ### メンバー（league_members）
 - リーグを**運営・管理するユーザー**

--- a/docs/issues/issue-05-refactor-player-role-schema.md
+++ b/docs/issues/issue-05-refactor-player-role-schema.md
@@ -1,0 +1,181 @@
+# Issue #05: データベーススキーマのリファクタリング（権限管理の統合）
+
+## ステータス
+🔴 **Open**
+
+## 優先度
+🔥 **High** - API設計に影響するため早期対応が必要
+
+## 概要
+
+`league_members`テーブルを削除し、`players`テーブルに`role`カラムを追加する。
+
+## 背景
+
+現在の設計では以下の2つのテーブルが存在する：
+- `players` - リーグで麻雀を打つ人（8人または16人）
+- `league_members` - リーグを運営・管理するユーザー
+
+しかし、実際の運用では：
+- **権限を持つ人（admin、scorer、viewer）は必ずプレイヤーとして参加している**
+- 2つのテーブルを別々に管理するのは冗長で複雑
+
+→ `players`テーブルに権限を統合する方がシンプルで運用に合っている
+
+## 変更内容
+
+### 1. スキーマ修正
+
+#### ❌ 削除
+- `db/schema/league-members.ts` ファイルを削除
+- `league_members` テーブルを削除
+
+#### ✅ 追加
+`db/schema/players.ts` に `role` カラムを追加：
+
+```typescript
+export const playersTable = pgTable('players', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  leagueId: uuid('league_id').notNull().references(() => leaguesTable.id),
+  name: varchar('name', { length: 20 }).notNull(),
+  userId: uuid('user_id').references(() => usersTable.id),
+  role: userRoleEnum('role'),  // 追加（nullable）
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})
+```
+
+**ルール:**
+- `userId` が `null` の場合、`role` も `null`（ゲストプレイヤー）
+- ユーザーと紐づいた後、権限を付与可能
+- `role`: `'admin' | 'scorer' | 'viewer' | null`
+
+#### ✅ 修正
+
+**`db/schema/index.ts`**
+```typescript
+// 削除
+export * from './league-members'  // ← この行を削除
+
+// 残すもの
+export * from './leagues'
+export * from './link-requests'
+export * from './players'
+export * from './scores'
+export * from './sessions'
+export * from './tables'
+export * from './users'
+```
+
+**`db/schema/leagues.ts` のリレーション**
+```typescript
+export const leaguesRelations = relations(leaguesTable, ({ one, many }) => ({
+  creator: one(usersTable, {
+    fields: [leaguesTable.createdBy],
+    references: [usersTable.id],
+  }),
+  // members: many(leagueMembersTable),  // ← 削除
+  players: many(playersTable),
+  sessions: many(sessionsTable),
+}))
+```
+
+**`db/schema/users.ts` のリレーション**
+```typescript
+export const usersRelations = relations(usersTable, ({ many }) => ({
+  createdLeagues: many(leaguesTable),
+  // leagueMembers: many(leagueMembersTable),  // ← 削除
+  players: many(playersTable),
+  linkRequests: many(linkRequestsTable),
+}))
+```
+
+### 2. マイグレーション
+
+```bash
+# スキーマ修正後
+bun run db:generate
+
+# 生成されたマイグレーションSQL確認
+cat drizzle/0001_*.sql
+
+# DBに適用
+bun run db:push
+```
+
+**想定されるマイグレーション内容:**
+```sql
+-- league_membersテーブル削除
+DROP TABLE IF EXISTS "league_members";
+
+-- playersテーブルにroleカラム追加
+ALTER TABLE "players" ADD COLUMN "role" "user_role";
+```
+
+### 3. データベース設計書の更新
+
+`docs/database-design.md` を更新：
+- `league_members` テーブルの説明を削除
+- `players` テーブルに `role` カラムの説明を追加
+
+## タスクリスト
+
+- [ ] `db/schema/league-members.ts` を削除
+- [ ] `db/schema/players.ts` に `role` カラムを追加
+- [ ] `db/schema/index.ts` から `league-members` のエクスポートを削除
+- [ ] `db/schema/leagues.ts` のリレーション修正
+- [ ] `db/schema/users.ts` のリレーション修正
+- [ ] `league_status` に `deleted` を追加（ついでに）
+- [ ] マイグレーションファイル生成（`bun run db:generate`）
+- [ ] マイグレーションSQL確認
+- [ ] マイグレーション適用（`bun run db:push`）
+- [ ] `docs/database-design.md` を更新
+- [ ] `docs/api-design.md` を更新（メンバー管理API削除、プレイヤー管理API更新）
+
+## 影響範囲
+
+### データベース
+- ✅ `league_members` テーブル削除
+- ✅ `players` テーブルに `role` カラム追加
+- ✅ 関連するリレーション修正
+
+### API設計
+- ❌ メンバー管理API削除
+  - `POST /api/leagues/:id/members`
+  - `PATCH /api/leagues/:id/members/:userId`
+  - `DELETE /api/leagues/:id/members/:userId`
+
+- ✅ プレイヤー管理APIに権限管理機能を追加
+  - `PATCH /api/leagues/:id/players/:playerId/role` - 権限変更
+
+### フロントエンド
+- 今後実装時に考慮（まだ未実装）
+
+## 検証方法
+
+1. **スキーマ確認**
+   ```bash
+   # playersテーブルにroleカラムがあるか確認
+   bunx supabase db dump --schema public
+   ```
+
+2. **Drizzle Studio確認**
+   ```bash
+   bun run db:studio
+   # http://localhost:4983 でテーブル構造確認
+   ```
+
+3. **データ整合性確認**
+   - リーグ作成時、プレイヤーが正しく作成されるか
+   - ユーザーと紐づけ後、権限が付与できるか
+
+## 参考資料
+
+- [database-design.md](../database-design.md)
+- [api-design.md](../api-design.md)
+- [Drizzle ORM - Schema](https://orm.drizzle.team/docs/sql-schema-declaration)
+
+---
+
+**作成日:** 2025-11-08
+**担当者:** TBD


### PR DESCRIPTION
📝 作成したissue
docs/issues/issue-05-refactor-player-role-schema.md

内容
タイトル: データベーススキーマのリファクタリング（権限管理の統合）
概要: league_members削除、playersにrole追加
背景: 権限を持つ人は必ずプレイヤーなので統合する方がシンプル
タスクリスト: 11項目の詳細な手順
影響範囲: データベース、API設計への影響を明記
