### PR TITLE
fix: pre-push で変更ファイルのみ lint チェックするように修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,4 +8,5 @@ pre-commit:
 pre-push:
   commands:
     biome-check:
-      run: bun run lint
+      glob: "**/*.{ts,tsx,js,jsx,cts,mts,cjs,mjs}"
+      run: bunx biome check --no-errors-on-unmatched {push_files}


### PR DESCRIPTION
問題:
- pre-push で全ファイルをチェックしていた
- main ブランチに既存の lint エラーがある場合、 新しいブランチでも push 時にエラーが出る

修正:
- {push_files} を使って変更されたファイルのみチェック
- main の既存エラーに影響されなくなる

これにより、自分の変更だけをチェックできるようになり、
main から切ったブランチでも不要なエラーが出なくなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 概要
- このPRで解決する一点（1〜2行）

## 変更点
- 箇条書き（機能/非機能/Flag/破壊的変更があれば明記）


