### PR TITLE
Feature/gh 58

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,727 +1,192 @@
 # CLAUDE.md
 
-このファイルは、Claude Code（claude.ai/code）が本リポジトリのコードを扱う際のガイドラインを示します。
-
----
+Claude Code（claude.ai/code）用ガイドライン。
 
 ## 基本方針
 
-- 不明な点は積極的に質問する
-- 質問する時は常に AskUserQuestion を使って回答させる
-- **選択肢にはそれぞれ、推奨度と理由を提示する**
-  - 推奨度は ⭐ の 5 段階評価
+- 不明点は積極的に質問する (`AskUserQuestion`)
+- **選択肢には推奨度（⭐5段階）と理由を提示する**
 
 ## プロジェクト概要
 
-Next.js App Router、Hono、Drizzle ORM、Supabase を用いた麻雀リーグ管理アプリケーション。
-
----
+Next.js 15 (App Router), Hono, Drizzle ORM, Supabase を用いた麻雀リーグ管理アプリ。
 
 ## 開発コマンド
 
-### セットアップ & 開発サーバー起動
-
 ```bash
-bun install                # 依存パッケージのインストール
-bun run dev                # Next.js 開発サーバー起動 (localhost:3000)
-bunx supabase start        # Supabase ローカル環境起動
-bunx supabase stop         # Supabase ローカル環境停止
+bun install                # 依存インストール
+bun run dev                # Next.js 開発サーバー (localhost:3000)
+bunx supabase start/stop   # Supabase ローカル起動/停止
+
+bun run lint               # Biome チェック
+bun run lint:fix           # Biome 自動修正
+bun run format             # Biome 整形
+# ※ VSCode `formatOnSave: true` 推奨。lefthookはチェックのみ。
+
+bun run db:generate        # マイグレーション生成
+bun run db:migrate         # DB適用
+bun run db:push            # スキーマ直接反映 (開発用)
+bun run db:studio          # Drizzle Studio 起動
 ```
-
-### コード品質管理
-
-```bash
-bun run lint               # Biome によるコードチェック（サマリー表示）
-bun run lint:fix           # Biome による自動修正
-bun run format             # Biome によるコード整形
-```
-
-**Lint/Format のワークフロー:**
-- **保存時自動修正 + コミット時チェック**の構成
-  - VSCode: `editor.formatOnSave: true` で保存時に自動修正
-  - Lefthook: `pre-commit` ではチェックのみ（修正しない）
-  - 理由: 二重実行を避け、開発体験を最適化
-  - lefthook.yml の設定:
-    ```yaml
-    pre-commit:
-      commands:
-        biome:
-          run: bunx biome check --no-errors-on-unmatched {staged_files}
-          # ❌ lint:fix は使わない（保存時に既に修正済み）
-    ```
-
-### データベース（Drizzle + Supabase）
-
-```bash
-bun run db:generate        # スキーマ変更からマイグレーション SQL を生成
-bun run db:migrate         # マイグレーションを DB に適用
-bun run db:push            # スキーマを DB に直接反映（ローカル開発向け）
-bun run db:studio          # Drizzle Studio の UI を起動
-```
-
-スキーマ変更後は `bun run db:generate` → `bun run db:migrate` を実行。
-
----
 
 ## アーキテクチャ
 
-### 技術スタック
+**構成**: `Routes (RPC) → Services (Logic) → Repositories (DB) → Database`
 
-| 種別           | 使用技術                                       |
-| -------------- | ---------------------------------------------- |
-| フロントエンド | Next.js 15 (App Router), React 19, React Query |
-| バックエンド   | Hono（RPC + OpenAPI の二重 API）               |
-| DB/ORM         | Supabase PostgreSQL + Drizzle ORM              |
-| 認証           | Supabase Auth (JWT/Bearer)                     |
-| バリデーション | Zod                                            |
-| Lint/Format    | Biome                                          |
-| Git Hooks      | Lefthook                                       |
+| 種別 | 技術 | 備考 |
+| --- | --- | --- |
+| フロント | Next.js 15, React 19, React Query | App Router |
+| バック | Hono | RPC + OpenAPI の二重構成 |
+| DB | Supabase (PostgreSQL), Drizzle ORM | |
+| 認証 | Supabase Auth | JWT/Bearer |
+| 検証 | Zod | `src/schemas/` で共通化 |
 
----
+**ディレクトリ**:
+- `app/api/`: Honoマウント
+- `src/client/`: RPCクライアント, Hooks
+- `src/server/`: Routes(RPC), OpenAPI, Services, Repositories
+- `db/`: Drizzleスキーマ
 
-## ディレクトリ構成
+## 実装ガイドライン
 
-```
-app/
-  api/[...route]/route.ts     # Next.js APIルート - Honoアプリをマウント
-  layout.tsx, page.tsx        # App Router ページ
+### 1. 認証 (Supabase SSR)
 
-src/
-  schemas/                    # 共有 Zod スキーマ（フロント・バック共通）
-  types/                      # 共有 TypeScript 型定義
-
-  client/
-    api.ts                    # Hono RPC クライアント定義 (hc)
-    hooks/                    # React Query hooks
-
-  server/
-    routes/                   # Hono RPC ルート（型安全 API）
-      index.ts                # RPC メインアプリ (AppType export)
-
-    openapi/                  # Hono OpenAPI ルート
-      index.ts                # Swagger UI を `/api/ui` で提供
-      routes/                 # OpenAPI定義
-      schemas/                # Zod OpenAPIスキーマ（.openapi()でデコレート）
-
-    services/                 # ビジネスロジック層
-    repositories/             # Drizzle ORM による DB アクセス層
-    actions/                  # Server Actions（SSR用データ取得）
-    middleware/
-      auth.ts                 # Supabase JWT 認証
-      error-handler.ts        # エラーハンドラー
-
-db/
-  schema/                     # Drizzle スキーマ定義
-  index.ts                    # Drizzle クライアント初期化
-
-drizzle/                      # マイグレーション生成物
-```
-
----
-
-## API 構成：RPC + OpenAPI の二重パターン
-
-| 種類                                | 用途                                      |
-| ----------------------------------- | ----------------------------------------- |
-| RPC API (`src/server/routes/`)      | フロントエンド用の型安全通信              |
-| OpenAPI API (`src/server/openapi/`) | Swagger UI による REST API ドキュメント提供 |
-
-Swagger UI: `http://localhost:3000/api/ui`
-
----
-
-## レイヤード構造
-
-```
-Routes → Services → Repositories → Database
-```
-
-| レイヤー     | 役割                            |
-| ------------ | ------------------------------- |
-| Routes       | HTTP 処理、認証、バリデーション |
-| Services     | ビジネスロジック                |
-| Repositories | Drizzle ORM による DB アクセス  |
-| Database     | Supabase PostgreSQL             |
-
-フロー例: `routes → services → repositories → db`
-
----
-
-## 認証の実装パターン
-
-### Supabase SSR の使用
-
-- **Server Component での認証**: `@supabase/ssr` の `createServerClient` を使用
-- **Client Component での認証**: `@supabase/ssr` の `createBrowserClient` を使用
-- **Middleware での認証トークン更新**: `middleware.ts` で全リクエストに対してトークンをリフレッシュ
+- **Server**: `createServerClient` (`src/server/supabase.ts`)
+- **Client**: `useAuth()` フックを使用（`createBrowserClient` 直接使用禁止）
+- **AuthProvider**: ルートレイアウトでラップし、単一インスタンスを提供
 
 ```typescript
-// Server Component 用クライアント (src/server/supabase.ts)
-import { createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
-
-export async function createClient() {
-  const cookieStore = await cookies()
-  return createServerClient(url, anonKey, {
-    cookies: {
-      getAll() { return cookieStore.getAll() },
-      setAll(cookiesToSet) { /* ... */ }
-    }
-  })
-}
-
-// Client Component 用クライアント (src/client/supabase.ts)
-import { createBrowserClient } from '@supabase/ssr'
-
-export function createClient() {
-  return createBrowserClient(url, anonKey)
-}
-```
-
-### 認証状態の取得
-
-- **Server Component**: `await supabase.auth.getUser()` でサーバー側で取得
-- **Client Component**: インタラクティブな部分のみクライアントコンポーネント化
-- **非推奨**: `useAuth` のような Client 側専用フックは使わない（SSR を優先）
-
-### API 認証フロー（Hono RPC）
-
-1. フロントエンドは `Authorization: Bearer <JWT>` を送信
-2. `authMiddleware` が Supabase を用いて検証
-3. 認証ユーザー ID を `c.get('userId')` にセット
-4. Services で権限チェックに利用
-
-### AuthProvider の一元化（Client Component 用）
-
-**重要**: Client Component で認証機能が必要な場合（ログイン、ログアウトなど）は、`useAuth()` フックを使用する。
-
-- **全てのコンポーネントで `useAuth()` フックを使用する**
-  - 各コンポーネントで `createClient()` を直接呼び出さない
-  - Supabase クライアントインスタンスは AuthProvider が提供する単一のインスタンスを使用
-  - 認証関連の操作（signIn, signOut）は AuthProvider が提供するメソッドを使用
-
-- **AuthProvider は必ずルートレイアウトで有効化する**
-  - `app/layout.tsx` で `Providers` コンポーネントをラップ
-  - 全ページで認証状態にアクセス可能にする
-
-```typescript
-// ❌ Bad - コンポーネントで直接クライアント作成
-const [supabase] = useState(() => createClient())
-const handleLogin = async () => {
-  await supabase.auth.signInWithPassword(...)
-}
-
 // ✅ Good - useAuth フックを使用
 const { signIn, signOut, user } = useAuth()
-const handleLogin = async () => {
-  await signIn(email, password)
-}
+const handleLogin = async () => await signIn(email, password)
 ```
 
-## コンポーネント設計パターン
+### 2. コンポーネント設計
 
-### Container/Presentational パターンの採用
-
-リーグ一覧など、データ取得とUIを分離する場合は以下のパターンを使用:
-
-```
-components/features/[feature]/
-├── [feature]-list.tsx        # Presentational（見た目のみ）
-└── [feature]-container.tsx   # Container（ロジック）
-
-app/[feature]/
-└── page.tsx                  # Server Component（データ取得）
-
-src/server/actions/
-└── [feature].ts              # Server Action（データ取得関数）
-```
-
-**役割**:
-- **page.tsx**: Server Component でデータ取得（SSR）
-- **Container**: React Query でキャッシュ管理、ルーティング
-- **Presentational**: Props で受け取った値を表示のみ
-
-### Next.js App Router の params 扱い
-
-- **App Router のページ params は Promise**
-  - Next.js 15 以降、params は非同期になった
-  - 使用前に必ず `await` する必要がある
+- **Container/Presentational**: ロジック(`-container.tsx`)と表示(`-list.tsx`)を分離
+- **Next.js 15 Params**: `await params` が必須
+- **共有型**: Server Actionの戻り値型 `Awaited<ReturnType<typeof func>>` を利用
 
 ```typescript
-// ❌ Bad - params を await せずに使用
-export default async function Page({ params }: { params: { id: string } }) {
-  const { id } = params  // エラー: params should be awaited
-}
-
-// ✅ Good - params を Promise として扱い await する
+// ✅ Good - params を await する
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 }
 ```
 
-### 共有データ型の参照
+### 3. スキーマ & バリデーション (Zod)
 
-- **サーバー側の戻り値型を参照する**
-  - コンポーネントごとに同じ形を再定義しない
-  - `Awaited<ReturnType<typeof functionName>>` を使用
-
-```typescript
-// ❌ Bad - コンポーネントごとに型を再定義
-interface LeagueDetailContainerProps {
-  initialData: {
-    id: string
-    name: string
-    description: string | null
-    // ... 全フィールドを手動で定義
-  }
-}
-
-// ✅ Good - Server Action の戻り値型を参照
-interface LeagueDetailContainerProps {
-  initialData: Awaited<ReturnType<typeof getLeagueForUser>>
-}
-```
-
----
-
-## スキーマとバリデーションの管理
-
-### Zod スキーマの共通化
-
-**`src/schemas/` にベーススキーマを配置**:
-- フロント・バック両方で使用可能な基本 Zod スキーマ
-- `zod` パッケージを使用（`@hono/zod-openapi` ではない）
-
-**RPC ルート（`src/server/routes/`）**:
-- `@/src/schemas/` から直接 import
-
-**OpenAPI スキーマ（`src/server/openapi/schemas/`）**:
-- `@/src/schemas/` からベーススキーマを import
-- `.openapi()` でメタデータ追加
-- `.extend()` で拡張可能
-
-### Zod スキーマの一元化
-
-UI コンポーネント内でバリデーションロジックを直接記述せず、`src/schemas/` で定義した Zod スキーマを使用する:
-
-```typescript
-// ❌ Bad - コンポーネント内に重複したバリデーション
-if (!name) {
-  setError('名前は必須です')
-  return
-}
-if (name.length > 20) {
-  setError('名前は20文字以内で入力してください')
-  return
-}
-
-// ✅ Good - Zod スキーマでバリデーション
-import { playerNameSchema } from '@/src/schemas/leagues'
-
-const validationResult = playerNameSchema.shape.name.safeParse(input.trim())
-if (!validationResult.success) {
-  setError(validationResult.error.issues[0].message)
-  return
-}
-```
-
-**メリット**:
-- バリデーションルールとエラーメッセージがスキーマ定義に集約される
-- フロントエンド・バックエンドで同じルールを共有できる
-- 将来的な変更時、修正箇所が一箇所に限定される
-
-例:
+- **共通化**: `src/schemas/` にベースを定義し、RPC/OpenAPI双方から参照
+- **DRY**: コンポーネント内でバリデーションを書かず、スキーマを利用
+- **OpenAPI**: ベーススキーマを `.extend().openapi()` で拡張し、ロジック重複を避ける
+  - ⚠️ **制限事項**: `zod` と `@hono/zod-openapi` は型互換性がないため、複雑なバリデーション（`.refine()` など）を持つスキーマは `.extend()` でインポートできない場合があります。その場合はコメントで関係性を明記し、バリデーションロジックを再定義してください。
 
 ```typescript
 // src/schemas/leagues.ts
-import { z } from 'zod'
+export const createLeagueSchema = z.object({ name: z.string().min(1).max(20) })
 
-export const createLeagueSchema = z.object({
-  name: z.string().min(1).max(20),
-  description: z.string().optional(),
-})
-
-export type CreateLeagueInput = z.infer<typeof createLeagueSchema>
-```
-
-```typescript
-// src/server/routes/leagues.ts
-import { createLeagueSchema } from '@/src/schemas/leagues'
-import { zValidator } from '@hono/zod-validator'
-
-app.post('/', zValidator('json', createLeagueSchema), async (c) => {
-  // ...
-})
-```
-
-```typescript
 // src/server/openapi/schemas/leagues.ts
-import { z } from '@hono/zod-openapi'
-import { createLeagueSchema } from '@/src/schemas/leagues'
-
+// ✅ Good - ベーススキーマを再利用（シンプルなスキーマの場合）
 export const CreateLeagueRequestSchema = createLeagueSchema
-  .extend({
-    name: z.string().min(1).max(20).openapi({
-      example: '2025 Spring League',
-      description: 'League name (1-20 characters)',
-    }),
-  })
+  .extend({ name: z.string().openapi({ example: 'League' }) })
   .openapi('CreateLeagueRequest')
+
+// ⚠️ 複雑なバリデーション（.refine()）がある場合は再定義が必要
+// src/server/schemas/scores.ts
+/**
+ * NOTE: バリデーションロジックはベーススキーマ（src/schemas/scores.ts）と同じですが、
+ * zod と @hono/zod-openapi の型互換性がないため、.extend() でインポートできません。
+ */
+export const UpdateTableScoresRequestSchema = z.object({ ... }).refine(...)
 ```
 
-### スキーマ定義の DRY 原則
+### 4. データベース
 
-**OpenAPI スキーマでのベーススキーマ再利用**:
-- `src/server/openapi/schemas/` や `src/server/schemas/` では、バリデーションロジックを重複定義しない
-- `src/schemas/` のベーススキーマを import し、`.openapi()` でメタデータを追加する
-- `.refine()` などの複雑なバリデーションロジックは必ずベーススキーマに定義し、OpenAPI スキーマでは `.extend()` で拡張のみ行う
+- **トランザクション**: 複数更新は必ず `db.transaction(async (tx) => ...)` で囲む
+- **環境変数**: `src/config/env.ts` 経由でアクセス（`process.env` 直接参照禁止）
 
 ```typescript
-// ❌ Bad - バリデーションロジックを重複定義
-export const UpdateRequestSchema = z
-  .object({ scores: z.array(...).length(4) })
-  .refine((data) => { /* 重複したロジック */ })
-  .openapi('UpdateRequest')
-
-// ✅ Good - ベーススキーマを再利用
-import { updateTableScoresSchema } from '@/src/schemas/scores'
-
-export const UpdateRequestSchema = updateTableScoresSchema
-  .extend({
-    scores: z.array(ScoreInputSchema).length(4).openapi({
-      description: '...',
-    }),
-  })
-  .openapi('UpdateRequest')
-```
-
-**メリット**:
-- バリデーションルールの Single Source of Truth を維持
-- フロント・バック間でのスキーマ drift を防止
-- 将来の変更時、修正箇所が一箇所に限定される
-
-### TypeScript 型定義の共通化
-
-**`src/types/` に配置**:
-- フロント・バック共通の TypeScript 型
-- API レスポンス型、エンティティ型など
-
-**注意**:
-- Date 型は JSON シリアライズ不可のため `string` (ISO 8601) を使用
-- Repository → Service 層で `Date` → `string` 変換
-
----
-
-## 環境変数の管理
-
-**`src/config/env.ts` で一元管理**:
-- 各ファイルで `process.env.VARIABLE_NAME` を直接参照しない
-- Non-null assertion (`!`) を使用しない
-- 検証付きゲッター関数経由でアクセス
-
-```typescript
-// ❌ Bad
-const url = process.env.DATABASE_URL!
-
-// ✅ Good
-import { getDatabaseUrl } from '@/src/config/env'
-const url = getDatabaseUrl()
-```
-
-```typescript
-// src/config/env.ts
-export function getDatabaseUrl(): string {
-  const databaseUrl = process.env.DATABASE_URL
-  if (!databaseUrl) {
-    throw new Error('DATABASE_URL must be defined in environment variables.')
-  }
-  return databaseUrl
-}
-```
-
----
-
-## エラーハンドリングとローディング状態
-
-### 非同期処理での状態管理
-
-**`finally` ブロックで状態をリセットする**:
-- 成功時・失敗時の両方で確実にローディング状態をリセット
-- Next.js の `router.push()` などのナビゲーション後も適切に状態管理
-
-### バリデーションエラーは適切なHTTPステータスコードで返す
-
-```typescript
-// ❌ Bad - 全てのエラーを一律に処理
-throw new Error('バリデーションエラー')  // グローバルハンドラーで500エラーになる
-
-// ✅ Good - HTTPExceptionを使って適切なステータスコードを返す
-import { BadRequestError } from '@/src/server/middleware/error-handler'
-
-if (players.length !== 16) {
-  throw new BadRequestError('第1節の作成にはプレイヤーが16名必要です')  // 400エラー
-}
-```
-
-**OpenAPI routeでエラーレスポンスを明示的に定義**:
-
-```typescript
-// ルート定義でバリデーションエラーのレスポンスを追加
-responses: {
-  201: { /* 成功レスポンス */ },
-  400: BadRequestResponse,  // バリデーションエラー用
-  401: UnauthorizedResponse,
-  403: ForbiddenResponse,
-  404: NotFoundResponse,
-}
-```
-
-**メリット**:
-- クライアントが適切なエラーハンドリングを行える
-- Swagger UIでエラーレスポンスがドキュメント化される
-- サーバーエラー（500）とクライアントエラー（400）が明確に区別される
-
----
-
-## セキュリティと認可
-
-### 現在のユーザーで権限チェックを行う
-
-```typescript
-// ❌ Bad - 任意の管理者が存在するかをチェック
-const isAdmin = league.players.some(
-  (player) => player.userId && player.role === 'admin'
-)
-// → 一般メンバーにも管理者機能が表示されてしまう
-
-// ✅ Good - 現在ログインしているユーザーが管理者かをチェック
-const isAdmin = league.players.some(
-  (player) => player.userId === currentUserId && player.role === 'admin'
-)
-```
-
-**Server Componentで認証情報を取得してpropsで渡す**:
-
-```typescript
-// app/xxx/page.tsx (Server Component)
-export default async function Page({ params }: PageProps) {
-  const user = await getCurrentUser()
-  if (!user) redirect('/login')
-
-  const data = await getDataForUser(params.id)
-
-  return <Container data={data} currentUserId={user.id} />
-}
-```
-
-**メリット**:
-- 権限チェックが正確になる
-- UIレベルで不正な操作を防げる
-- サーバー側の認可チェックと整合性が取れる
-
----
-
-## フロントエンド実装メモ（リーグ設定関連）
-
-- App Router の `params` は `Promise`。使用前に必ず `await params` する。
-- サーバーアクションの戻り値型を再利用する（例: `Awaited<ReturnType<typeof getLeagueForUser>>`）。型をコンポーネントごとに再定義しない。
-- React Hook Form の配列は `useFieldArray` で扱い、`watch` で全体再レンダリングを誘発しない。
-- 送信中フラグは `form.formState.isSubmitting` を使い、独自 state を持たない。
-- リーグ設定更新ではステータスも必ず `useUpdateLeagueStatus` で永続化する（名前・説明のみで終わらせない）。
-
-```typescript
-// ❌ Bad - 成功時に loading がリセットされない
-const onSubmit = async (data) => {
-  setLoading(true)
-  try {
-    await signIn(data)
-    if (error) {
-      setLoading(false) // エラー時のみリセット
-      return
-    }
-    router.push('/dashboard') // 成功時はリセットされず disabled のまま
-  } catch (err) {
-    setLoading(false)
-  }
-}
-
-// ✅ Good - finally で必ずリセット
-const onSubmit = async (data) => {
-  setLoading(true)
-  try {
-    await signIn(data)
-    if (error) {
-      return
-    }
-    router.push('/dashboard')
-  } catch (err) {
-    // エラーハンドリング
-  } finally {
-    setLoading(false) // 必ず実行される
-  }
-}
-```
-
-**理由**: ナビゲーション後にユーザーが戻ってきた場合でも、フォームが使用可能な状態を保つため。
-
----
-
-## 開発フロー：新機能追加
-
-1. `db/schema/` にスキーマ追加 → `db:generate` → `db:migrate`
-2. Repository 作成
-3. Service 作成
-4. `src/schemas/` にバリデーションスキーマ作成
-5. RPC ルート追加
-6. (任意) OpenAPI ルート追加
-7. `src/types/` に型定義追加
-8. React Query hook 作成
-9. UI コンポーネント実装
-
----
-
-## React コーディングベストプラクティス
-
-### 配列の不変性
-
-**props として受け取った配列を直接 mutate しない**:
-- `.sort()`, `.reverse()`, `.splice()` などの破壊的メソッドを使う前に、必ず配列のコピーを作成する
-- スプレッド構文 `[...array]` または `.slice()` を使用してコピーを作成
-
-```typescript
-// ❌ Bad - props を直接変更
-{session.tables
-  .sort((a, b) => a.tableNumber - b.tableNumber)
-  .map((table) => ...)}
-
-// ✅ Good - コピーを作成してからソート
-{[...session.tables]
-  .sort((a, b) => a.tableNumber - b.tableNumber)
-  .map((table) => ...)}
-```
-
-**理由**: React の不変性原則に違反すると、予期しない副作用やバグの原因となる
-
-### state 更新のベストプラクティス
-
-**useState の関数更新フォームを使用する**:
-- オブジェクトや配列の部分更新を行う場合、関数更新フォームを使用する
-- クロージャによる古い state 参照を防ぐ
-
-```typescript
-// ❌ Bad - クロージャで古い state を参照する可能性
-onChange={(e) => setState({ ...state, [id]: e.target.value })}
-
-// ✅ Good - 関数更新フォームで最新の state を参照
-onChange={(e) => setState((current) => ({ ...current, [id]: e.target.value }))}
-```
-
-**メリット**:
-- 常に最新の state を参照できる
-- React のバッチ処理と安全に連携できる
-- パフォーマンス最適化にも有利
-
-### マジックナンバーの定数化
-
-**繰り返し使用される数値は定数として定義する**:
-- 同じ数値リテラルが複数箇所（3箇所以上）で使用される場合、コンポーネント/モジュールのトップレベルで定数として定義する
-- 定数名はその意味を明確に表現する
-
-```typescript
-// ❌ Bad - マジックナンバーが複数箇所に散在
-const isValid = totalScore === 100000
-const remainingScore = 100000 - totalScore
-description: '合計点数は100,000点である必要があります'
-
-// ✅ Good - 定数として一箇所で定義
-const TOTAL_SCORE = 100000
-
-const isValid = totalScore === TOTAL_SCORE
-const remainingScore = TOTAL_SCORE - totalScore
-description: `合計点数は${TOTAL_SCORE.toLocaleString()}点である必要があります`
-```
-
-**メリット**:
-- 可読性と保守性の向上
-- 値の変更時、修正箇所が一箇所に限定される
-- 数値の意味が明確になる
-
----
-
-## データベース操作のベストプラクティス
-
-### トランザクションの使用
-
-**複数の関連する DB 更新はトランザクションで囲む**:
-- ループ内で複数の UPDATE/INSERT を実行する場合、必ず `db.transaction()` で囲む
-- 部分的な更新が残ることでデータ不整合が発生するのを防ぐ
-
-```typescript
-// ❌ Bad - ループ内の個別更新（途中でエラーが発生すると部分更新が残る）
-for (const item of items) {
-  await repository.updateScore(item.id, { ... })
-}
-
 // ✅ Good - トランザクション内で実行
 await db.transaction(async (tx) => {
   for (const item of items) {
-    await tx.update(scoresTable)
-      .set({ ... })
-      .where(eq(scoresTable.id, item.id))
+    await tx.update(scoresTable).set({ ... }).where(eq(scoresTable.id, item.id))
   }
 })
 ```
 
-**重要**: トランザクション内では repository メソッドではなく、`tx` オブジェクトを使用して直接 Drizzle ORM のメソッドを呼び出す
+### 5. UI/UX (shadcn/ui) & React
 
----
+- **追加**: `bunx shadcn@latest add <component>` (必要なものだけ)
+- **'use client'**: `components/ui/` には付けず、利用側で付ける
+- **非同期状態**: `finally` でローディング状態を確実にリセット
+- **配列操作**: `sort`, `splice` 等はコピーを作成してから実行 (`[...array].sort()`)
+- **定数化**: 選択肢などは定数配列 + `.map()` で生成
+- **グローバル定数**: 複数ファイルで使用する定数は `src/constants/` に配置してインポート
 
-## UI/UX 開発の方針
+```typescript
+// ✅ Good - finally で必ずリセット
+try {
+  await signIn(data)
+  router.push('/dashboard')
+} catch (err) {
+  // エラー処理
+} finally {
+  setLoading(false)
+}
 
-### shadcn/ui
+// ❌ Bad - マジックナンバーが複数ファイルに分散
+// file1.ts
+const TOTAL_SCORE = 100000
+// file2.ts
+return total === 100000
 
-- 必要なコンポーネントを都度追加: `bunx shadcn@latest add <component>`
-- 事前に全コンポーネントをインストールしない
-- **`components/ui/` 内のコンポーネントには `'use client'` を追加しない**
-  - これらは shared components として Server/Client 両方から使えるべき
-  - `'use client'` は実際に使う側のコンポーネント（例: `create-league-dialog.tsx`）で宣言する
-
-### UI 定義の定数化
-
-**選択肢の動的生成**:
-
-ハードコードされた選択肢は定数配列として定義し、`.map()` で動的生成する:
-
-```tsx
-// ❌ Bad - ハードコード
-<RadioGroupItem value="8" id="player-count-8" />
-<label htmlFor="player-count-8">8人</label>
-<RadioGroupItem value="16" id="player-count-16" />
-<label htmlFor="player-count-16">16人</label>
-
-// ✅ Good - 定数 + map
-const PLAYER_COUNT_OPTIONS = [8, 16] as const
-
-{PLAYER_COUNT_OPTIONS.map((count) => (
-  <div key={count}>
-    <RadioGroupItem value={count.toString()} id={`player-count-${count}`} />
-    <label htmlFor={`player-count-${count}`}>{count}人</label>
-  </div>
-))}
+// ✅ Good - 共通定数ファイルを作成
+// src/constants/mahjong.ts
+export const TOTAL_SCORE = 100000
+// 各ファイルでインポート
+import { TOTAL_SCORE } from '@/src/constants/mahjong'
 ```
 
-**メリット**:
-- 選択肢の追加・変更が配列の修正のみで完結
-- 修正箇所が一箇所に限定される
-- タイポやコピペミスを防げる
+#### React Query キャッシュ無効化の最適化
 
-### デザイン原則
+mutation成功時のキャッシュ無効化は、できるだけ具体的なクエリキーを指定する。
 
-- 余計な情報は載せない
-- 実装する機能が決まっていない要素は表示しない
-- ユーザーから要件が提示されるまで推測で作り込まない
+```typescript
+// ❌ Bad - 全リーグのキャッシュを無効化（非効率）
+export const useUpdateScores = () => {
+  return useMutation({
+    mutationFn: async ({ tableId, scores }) => { /* ... */ },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['leagues'] })
+    },
+  })
+}
 
-### カラー指定
+// ✅ Good - 特定のリーグのキャッシュのみを無効化
+export const useUpdateScores = () => {
+  return useMutation({
+    mutationFn: async ({ tableId, leagueId, scores }) => { /* ... */ },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['leagues', variables.leagueId] })
+    },
+  })
+}
+```
 
-- shadcn/ui 変数を使用（`bg-primary`, `text-foreground` 等）
-- カスタム CSS 変数（`--ds-*`）を直接使わない
+### 6. セキュリティ & エラーハンドリング
+
+- **権限チェック**: 現在ログイン中のユーザーID (`currentUserId`) と比較する
+- **エラー**: `HTTPException` (Hono) や `BadRequestError` (Custom) を使用し、適切なステータスコードを返す
+
+```typescript
+// ✅ Good - 現在のユーザーで権限チェック
+const isAdmin = league.players.some(p => p.userId === currentUserId && p.role === 'admin')
+```
+
+## 開発フロー
+
+1. `db/schema/` 追加 → `db:generate` → `db:migrate`
+2. Repository → Service → Zod Schema 作成
+3. RPC Route (+ OpenAPI) 追加
+4. React Query Hook 作成
+5. UI 実装

--- a/app/api/[...route]/route.ts
+++ b/app/api/[...route]/route.ts
@@ -7,5 +7,6 @@ const mainApp = new Hono().route('/', app)
 
 export const GET = handle(mainApp)
 export const POST = handle(mainApp)
+export const PUT = handle(mainApp)
 export const PATCH = handle(mainApp)
 export const DELETE = handle(mainApp)

--- a/components/features/leagues/league-sessions-tab.tsx
+++ b/components/features/leagues/league-sessions-tab.tsx
@@ -52,7 +52,7 @@ export function LeagueSessionsTab({
           <AlertDescription>節一覧の取得に失敗しました: {sessionsError.message}</AlertDescription>
         </Alert>
       ) : (
-        <SessionList sessions={sessions} />
+        <SessionList leagueId={league.id} sessions={sessions} />
       )}
     </div>
   )

--- a/components/features/scores/score-input-dialog.tsx
+++ b/components/features/scores/score-input-dialog.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useToast } from '@/hooks/use-toast'
+import { useUpdateScores } from '@/src/client/hooks/useScores'
+import type { SessionScore } from '@/src/types/session'
+
+interface ScoreInputDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  tableId: string
+  tableType: 'first' | 'upper' | 'lower'
+  scores: SessionScore[]
+}
+
+const WIND_LABELS: Record<string, string> = {
+  east: '東',
+  south: '南',
+  west: '西',
+  north: '北',
+}
+
+const WIND_ORDER: Record<string, number> = {
+  east: 0,
+  south: 1,
+  west: 2,
+  north: 3,
+}
+
+export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreInputDialogProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const updateScores = useUpdateScores()
+
+  // 風順にソート
+  const sortedScores = useMemo(
+    () => [...scores].sort((a, b) => WIND_ORDER[a.wind] - WIND_ORDER[b.wind]),
+    [scores],
+  )
+
+  // フォーム状態（scoreId → finalScore のマップ）
+  const [inputScores, setInputScores] = useState<Record<string, string>>({})
+
+  // scoresが変更されたときに状態をリセット（別のテーブルに切り替わった場合など）
+  useEffect(() => {
+    setInputScores(
+      Object.fromEntries(sortedScores.map((s) => [s.id, s.finalScore?.toString() || ''])),
+    )
+  }, [sortedScores])
+
+  // 合計点チェック
+  const totalScore = useMemo(() => {
+    return Object.values(inputScores).reduce((sum, val) => {
+      const num = Number.parseInt(val, 10)
+      return sum + (Number.isNaN(num) ? 0 : num)
+    }, 0)
+  }, [inputScores])
+
+  const isValid = totalScore === 100000
+
+  const handleSubmit = async () => {
+    if (!isValid) {
+      toast({
+        variant: 'destructive',
+        title: '入力エラー',
+        description: '合計点数は100,000点である必要があります',
+      })
+      return
+    }
+
+    try {
+      await updateScores.mutateAsync({
+        tableId,
+        scores: {
+          scores: sortedScores.map((s) => ({
+            scoreId: s.id,
+            finalScore: Number.parseInt(inputScores[s.id], 10),
+          })),
+        },
+      })
+
+      toast({
+        title: 'スコアを更新しました',
+        description: 'ポイントが自動計算されました',
+      })
+
+      onOpenChange(false)
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to update scores:', error)
+      toast({
+        variant: 'destructive',
+        title: 'スコア更新に失敗しました',
+        description: error instanceof Error ? error.message : 'もう一度お試しください',
+      })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>スコア入力</DialogTitle>
+          <DialogDescription>
+            4人分の最終得点を入力してください。合計は100,000点である必要があります。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {sortedScores.map((score) => (
+            <div key={score.id} className="grid grid-cols-4 items-center gap-4">
+              <Label className="text-right">
+                {WIND_LABELS[score.wind]} {score.player.name}
+              </Label>
+              <Input
+                type="number"
+                className="col-span-2"
+                value={inputScores[score.id]}
+                onChange={(e) => setInputScores({ ...inputScores, [score.id]: e.target.value })}
+                placeholder="25000"
+              />
+              <span className="text-sm text-muted-foreground">点</span>
+            </div>
+          ))}
+
+          <div className="flex items-center justify-between border-t pt-4">
+            <span className="font-medium">合計:</span>
+            <span className={`font-bold ${isValid ? 'text-green-600' : 'text-red-600'}`}>
+              {totalScore.toLocaleString()} 点
+            </span>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateScores.isPending}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!isValid || updateScores.isPending}
+          >
+            {updateScores.isPending ? '保存中...' : '保存'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/features/scores/score-input-dialog.tsx
+++ b/components/features/scores/score-input-dialog.tsx
@@ -39,6 +39,11 @@ const WIND_ORDER: Record<string, number> = {
   north: 3,
 }
 
+/**
+ * 麻雀の配給原点（4人分の合計点数）
+ */
+const TOTAL_SCORE = 100000
+
 export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreInputDialogProps) {
   const router = useRouter()
   const { toast } = useToast()
@@ -73,15 +78,15 @@ export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreI
     }, 0)
   }, [inputScores])
 
-  const isValid = totalScore === 100000
-  const remainingScore = 100000 - totalScore
+  const isValid = totalScore === TOTAL_SCORE
+  const remainingScore = TOTAL_SCORE - totalScore
 
   const handleSubmit = async () => {
     if (!isValid) {
       toast({
         variant: 'destructive',
         title: '入力エラー',
-        description: '合計点数は100,000点である必要があります',
+        description: `合計点数は${TOTAL_SCORE.toLocaleString()}点である必要があります`,
       })
       return
     }
@@ -121,7 +126,7 @@ export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreI
           <DialogTitle>スコア入力</DialogTitle>
           <DialogDescription>
             4人分の最終得点を入力してください（百の位まで）。合計は1,000（=
-            100,000点）である必要があります。
+            {TOTAL_SCORE.toLocaleString()}点）である必要があります。
           </DialogDescription>
         </DialogHeader>
 
@@ -135,7 +140,12 @@ export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreI
                 type="number"
                 className="col-span-2"
                 value={inputScores[score.id]}
-                onChange={(e) => setInputScores({ ...inputScores, [score.id]: e.target.value })}
+                onChange={(e) =>
+                  setInputScores((currentScores) => ({
+                    ...currentScores,
+                    [score.id]: e.target.value,
+                  }))
+                }
                 placeholder="250"
                 min="0"
                 max="2000"
@@ -153,7 +163,7 @@ export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreI
               </div>
               <div className="text-xs text-muted-foreground">
                 {remainingScore === 0 ? (
-                  <span className="text-green-600">✓ 合計100,000点</span>
+                  <span className="text-green-600">✓ 合計{TOTAL_SCORE.toLocaleString()}点</span>
                 ) : remainingScore > 0 ? (
                   <span>残り: {remainingScore.toLocaleString()}点</span>
                 ) : (

--- a/components/features/scores/score-input-dialog.tsx
+++ b/components/features/scores/score-input-dialog.tsx
@@ -15,11 +15,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useToast } from '@/hooks/use-toast'
 import { useUpdateScores } from '@/src/client/hooks/useScores'
+import { TOTAL_SCORE } from '@/src/constants/mahjong'
 import type { SessionScore } from '@/src/types/session'
 
 interface ScoreInputDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  leagueId: string
   tableId: string
   tableType: 'first' | 'upper' | 'lower'
   scores: SessionScore[]
@@ -39,12 +41,13 @@ const WIND_ORDER: Record<string, number> = {
   north: 3,
 }
 
-/**
- * 麻雀の配給原点（4人分の合計点数）
- */
-const TOTAL_SCORE = 100000
-
-export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreInputDialogProps) {
+export function ScoreInputDialog({
+  open,
+  onOpenChange,
+  leagueId,
+  tableId,
+  scores,
+}: ScoreInputDialogProps) {
   const router = useRouter()
   const { toast } = useToast()
   const updateScores = useUpdateScores()
@@ -93,6 +96,7 @@ export function ScoreInputDialog({ open, onOpenChange, tableId, scores }: ScoreI
 
     try {
       await updateScores.mutateAsync({
+        leagueId,
         tableId,
         scores: {
           scores: sortedScores.map((s) => ({

--- a/components/features/sessions/session-list.tsx
+++ b/components/features/sessions/session-list.tsx
@@ -13,6 +13,7 @@ import type { Session } from '@/src/types/session'
 import { ScoreInputDialog } from '../scores/score-input-dialog'
 
 interface SessionListProps {
+  leagueId: string
   sessions: Session[]
 }
 
@@ -48,7 +49,7 @@ const WIND_ORDER: Record<string, number> = {
 /**
  * 節一覧コンポーネント
  */
-export function SessionList({ sessions }: SessionListProps) {
+export function SessionList({ leagueId, sessions }: SessionListProps) {
   const [selectedTable, setSelectedTable] = useState<{
     tableId: string
     tableType: 'first' | 'upper' | 'lower'
@@ -155,6 +156,7 @@ export function SessionList({ sessions }: SessionListProps) {
         <ScoreInputDialog
           open={!!selectedTable}
           onOpenChange={(open) => !open && setSelectedTable(null)}
+          leagueId={leagueId}
           tableId={selectedTable.tableId}
           tableType={selectedTable.tableType}
           scores={selectedTable.scores}

--- a/components/features/sessions/session-list.tsx
+++ b/components/features/sessions/session-list.tsx
@@ -1,13 +1,16 @@
 'use client'
 
+import { useState } from 'react'
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { Session } from '@/src/types/session'
+import { ScoreInputDialog } from '../scores/score-input-dialog'
 
 interface SessionListProps {
   sessions: Session[]
@@ -46,6 +49,12 @@ const WIND_ORDER: Record<string, number> = {
  * 節一覧コンポーネント
  */
 export function SessionList({ sessions }: SessionListProps) {
+  const [selectedTable, setSelectedTable] = useState<{
+    tableId: string
+    tableType: 'first' | 'upper' | 'lower'
+    scores: Session['tables'][0]['scores']
+  } | null>(null)
+
   if (sessions.length === 0) {
     return (
       <Card>
@@ -57,57 +66,100 @@ export function SessionList({ sessions }: SessionListProps) {
   }
 
   return (
-    <div className="space-y-4">
-      {sessions.map((session) => (
-        <Card key={session.id}>
-          <CardHeader>
-            <CardTitle>第{session.sessionNumber}節</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              作成日: {new Date(session.createdAt).toLocaleDateString('ja-JP')}
-            </p>
-          </CardHeader>
-          <CardContent>
-            <Accordion type="single" collapsible className="w-full">
-              {session.tables
-                .sort((a, b) => a.tableNumber - b.tableNumber)
-                .map((table) => (
-                  <AccordionItem key={table.id} value={`table-${table.id}`}>
-                    <AccordionTrigger>
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">{table.tableNumber}卓</span>
-                        <span className="text-sm text-muted-foreground">
-                          ({TABLE_TYPE_LABELS[table.tableType]})
-                        </span>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                      <div className="grid gap-2 sm:grid-cols-2">
-                        {table.scores
-                          .sort((a, b) => WIND_ORDER[a.wind] - WIND_ORDER[b.wind])
-                          .map((score) => (
-                            <div
-                              key={score.id}
-                              className="flex items-center justify-between rounded-lg border bg-card p-3 text-sm"
-                            >
-                              <div className="flex items-center gap-2">
-                                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-xs font-medium">
-                                  {WIND_LABELS[score.wind]}
-                                </span>
-                                <span className="font-medium">{score.player.name}</span>
-                              </div>
-                              {score.rank !== null && (
-                                <span className="text-muted-foreground">{score.rank}位</span>
-                              )}
+    <>
+      <div className="space-y-4">
+        {sessions.map((session) => (
+          <Card key={session.id}>
+            <CardHeader>
+              <CardTitle>第{session.sessionNumber}節</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                作成日: {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+              </p>
+            </CardHeader>
+            <CardContent>
+              <Accordion type="single" collapsible className="w-full">
+                {session.tables
+                  .sort((a, b) => a.tableNumber - b.tableNumber)
+                  .map((table) => {
+                    const allScoresEntered = table.scores.every((s) => s.rank !== null)
+
+                    return (
+                      <AccordionItem key={table.id} value={`table-${table.id}`}>
+                        <AccordionTrigger>
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{table.tableNumber}卓</span>
+                            <span className="text-sm text-muted-foreground">
+                              ({TABLE_TYPE_LABELS[table.tableType]})
+                            </span>
+                            {allScoresEntered && (
+                              <span className="text-xs text-green-600">✓ 入力済み</span>
+                            )}
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          <div className="space-y-4">
+                            <div className="grid gap-2 sm:grid-cols-2">
+                              {table.scores
+                                .sort((a, b) => WIND_ORDER[a.wind] - WIND_ORDER[b.wind])
+                                .map((score) => (
+                                  <div
+                                    key={score.id}
+                                    className="flex items-center justify-between rounded-lg border bg-card p-3 text-sm"
+                                  >
+                                    <div className="flex items-center gap-2">
+                                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                                        {WIND_LABELS[score.wind]}
+                                      </span>
+                                      <div>
+                                        <div className="font-medium">{score.player.name}</div>
+                                        {score.finalScore !== null && (
+                                          <div className="text-xs text-muted-foreground">
+                                            {score.finalScore.toLocaleString()}点 / {score.totalPt}
+                                            pt
+                                          </div>
+                                        )}
+                                      </div>
+                                    </div>
+                                    {score.rank !== null && (
+                                      <span className="text-muted-foreground">{score.rank}位</span>
+                                    )}
+                                  </div>
+                                ))}
                             </div>
-                          ))}
-                      </div>
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-            </Accordion>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="w-full"
+                              onClick={() =>
+                                setSelectedTable({
+                                  tableId: table.id,
+                                  tableType: table.tableType,
+                                  scores: table.scores,
+                                })
+                              }
+                            >
+                              スコアを入力
+                            </Button>
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    )
+                  })}
+              </Accordion>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {selectedTable && (
+        <ScoreInputDialog
+          open={!!selectedTable}
+          onOpenChange={(open) => !open && setSelectedTable(null)}
+          tableId={selectedTable.tableId}
+          tableType={selectedTable.tableType}
+          scores={selectedTable.scores}
+        />
+      )}
+    </>
   )
 }

--- a/components/features/sessions/session-list.tsx
+++ b/components/features/sessions/session-list.tsx
@@ -78,7 +78,7 @@ export function SessionList({ sessions }: SessionListProps) {
             </CardHeader>
             <CardContent>
               <Accordion type="single" collapsible className="w-full">
-                {session.tables
+                {[...session.tables]
                   .sort((a, b) => a.tableNumber - b.tableNumber)
                   .map((table) => {
                     const allScoresEntered = table.scores.every((s) => s.rank !== null)
@@ -99,7 +99,7 @@ export function SessionList({ sessions }: SessionListProps) {
                         <AccordionContent>
                           <div className="space-y-4">
                             <div className="grid gap-2 sm:grid-cols-2">
-                              {table.scores
+                              {[...table.scores]
                                 .sort((a, b) => WIND_ORDER[a.wind] - WIND_ORDER[b.wind])
                                 .map((score) => (
                                   <div

--- a/docs/issues/61-ranking-feature.md
+++ b/docs/issues/61-ranking-feature.md
@@ -1,0 +1,35 @@
+# ランキング・個人成績表示機能の実装
+
+**Issue**: #61
+**URL**: https://github.com/aki05162525/kojiro-mahjong-app/issues/61
+
+## 概要
+リーグ全体のランキング（順位表）と、プレイヤー個人の成績詳細を表示する機能を実装する。
+これにより、ユーザーは現在のリーグ状況や自分の成績を把握できるようになる。
+
+## タスク内容
+
+### 1. バックエンド実装
+- **集計ロジックの実装 (`src/server/repositories/ranking.ts`)**:
+    - `scores` テーブルからリーグIDに紐づく全スコアを集計。
+    - プレイヤーごとの `totalPt` (合計ポイント) を算出。
+    - ポイント順にソートして順位を決定。
+    - 各プレイヤーのスタッツ算出（対局数、トップ数、ラス数、平均順位、最大スコアなど）。
+- **API実装 (`src/server/routes/ranking.ts`)**:
+    - `GET /api/leagues/:leagueId/ranking`: ランキング情報取得
+
+### 2. フロントエンド実装
+- **React Query Hooks (`useRanking`)**:
+    - ランキングデータ取得用フック。
+- **ランキング表示コンポーネント (`components/features/ranking/ranking-table.tsx`)**:
+    - 順位、プレイヤー名、合計ポイント、各節の成績推移などをテーブル表示。
+    - shadcn/ui の Table コンポーネントを使用。
+- **リーグ詳細画面への統合**:
+    - `LeagueDetail` の「順位」タブにランキング表を配置。
+
+### 3. ドキュメント
+- API仕様書の更新。
+
+## 関連ドキュメント
+- `docs/requirements.md` (集計ルール)
+- `docs/todo.md`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,6 +43,15 @@
   - [x] Repositories: DB アクセス層 (`src/server/repositories/players.ts`)
   - [x] OpenAPI Schemas: players用スキーマ (`src/server/schemas/players.ts`)
 
+- [x] **スコア入力・計算機能実装（100%完了）**
+  - [x] Routes (RPC): スコア入力/取得/修正
+  - [x] Routes (OpenAPI): Swagger UI 対応
+  - [x] Services: 点数計算ロジック（scorePt, rank, rankPt, totalPt）
+  - [x] Services: 同点処理（座順優先）、合計点バリデーション（100,000点）
+  - [x] Repositories: DB アクセス層
+  - [x] Validators: Zod スキーマ
+  - [x] OpenAPI Schemas
+
 ### フロントエンド統合
 - [x] **React Query + Hono RPC 統合（100%完了）**
   - [x] RPC クライアント初期化（`src/client/api.ts`）
@@ -68,14 +77,10 @@
 ## 現在進行中
 
 ### バックエンド機能実装
-- [ ] **スコア入力・計算機能実装（0%完了）**
-  - [ ] Routes (RPC): スコア入力/取得/修正
-  - [ ] Routes (OpenAPI): Swagger UI 対応
-  - [ ] Services: 点数計算ロジック（scorePt, rank, rankPt, totalPt）
-  - [ ] Services: 同点処理（座順優先）、合計点バリデーション（100,000点）
-  - [ ] Repositories: DB アクセス層
-  - [ ] Validators: Zod スキーマ
-  - [ ] OpenAPI Schemas
+- [ ] **ランキング表示機能実装（0%完了）**
+  - [ ] Routes (RPC): リーグランキング取得、個人成績取得
+  - [ ] Services: 累積ポイント計算、ソートロジック
+  - [ ] Repositories: 集計クエリ
 
 ### フロントエンド UI 実装
 - [ ] **スコア入力画面**
@@ -84,7 +89,7 @@
   - [ ] 合計点バリデーション
 
 ### React Query フック作成
-- [ ] useScores (スコア入力用)
+- [x] useScores (スコア入力用)
 
 ## TODO (優先度順)
 
@@ -96,11 +101,6 @@
   - [ ] Repositories: DB アクセス層
   - [ ] Validators: Zod スキーマ
   - [ ] OpenAPI Schemas
-
-- [ ] **ランキング表示機能実装（0%完了）**
-  - [ ] Routes (RPC): リーグランキング取得、個人成績取得
-  - [ ] Services: 累積ポイント計算、ソートロジック
-  - [ ] Repositories: 集計クエリ
 
 - [ ] **ユーザー管理機能実装（0%完了）**
   - [ ] Routes (RPC/OpenAPI): ユーザー一覧/詳細/作成/更新

--- a/src/client/hooks/useScores.ts
+++ b/src/client/hooks/useScores.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { UpdateTableScoresInput } from '@/src/schemas/scores'
+import { apiClient } from '../api'
+
+/**
+ * スコア更新 mutation
+ */
+export const useUpdateScores = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      tableId,
+      scores,
+    }: {
+      tableId: string
+      scores: UpdateTableScoresInput
+    }) => {
+      const res = await apiClient.api.tables[':tableId'].scores.$put({
+        param: { tableId },
+        json: scores,
+      })
+
+      if (!res.ok) {
+        const error = await res.json()
+        throw new Error(error.error || 'Failed to update scores')
+      }
+    },
+    onSuccess: () => {
+      // セッション一覧を再取得（スコアが更新されたため）
+      queryClient.invalidateQueries({ queryKey: ['leagues'] })
+      queryClient.invalidateQueries({ queryKey: ['sessions'] })
+    },
+  })
+}

--- a/src/client/hooks/useScores.ts
+++ b/src/client/hooks/useScores.ts
@@ -22,14 +22,20 @@ export const useUpdateScores = () => {
       })
 
       if (!res.ok) {
-        const error = await res.json()
-        throw new Error(error.error || 'Failed to update scores')
+        // エラーレスポンスはJSONボディを持つ
+        try {
+          const error = await res.json()
+          throw new Error(error.error || 'Failed to update scores')
+        } catch {
+          throw new Error('Failed to update scores')
+        }
       }
+      // 204 No Content は正常終了（ボディなし）
     },
     onSuccess: () => {
       // セッション一覧を再取得（スコアが更新されたため）
+      // 全てのリーグとセッションのキャッシュを無効化
       queryClient.invalidateQueries({ queryKey: ['leagues'] })
-      queryClient.invalidateQueries({ queryKey: ['sessions'] })
     },
   })
 }

--- a/src/client/hooks/useScores.ts
+++ b/src/client/hooks/useScores.ts
@@ -14,6 +14,7 @@ export const useUpdateScores = () => {
       scores,
     }: {
       tableId: string
+      leagueId: string
       scores: UpdateTableScoresInput
     }) => {
       const res = await apiClient.api.tables[':tableId'].scores.$put({
@@ -32,10 +33,9 @@ export const useUpdateScores = () => {
       }
       // 204 No Content は正常終了（ボディなし）
     },
-    onSuccess: () => {
-      // セッション一覧を再取得（スコアが更新されたため）
-      // 全てのリーグとセッションのキャッシュを無効化
-      queryClient.invalidateQueries({ queryKey: ['leagues'] })
+    onSuccess: (_data, variables) => {
+      // 特定のリーグのセッション情報のみを無効化（効率的なキャッシュ更新）
+      queryClient.invalidateQueries({ queryKey: ['leagues', variables.leagueId] })
     },
   })
 }

--- a/src/constants/mahjong.ts
+++ b/src/constants/mahjong.ts
@@ -1,0 +1,4 @@
+/**
+ * 麻雀の配給原点（4人分の合計点数）
+ */
+export const TOTAL_SCORE = 100000

--- a/src/schemas/scores.ts
+++ b/src/schemas/scores.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+/**
+ * スコア入力データ（単一プレイヤー）
+ */
+export const scoreInputSchema = z.object({
+  scoreId: z.string().uuid(),
+  finalScore: z.number().int().min(0).max(200000),
+})
+
+/**
+ * テーブルスコア更新リクエスト
+ */
+export const updateTableScoresSchema = z
+  .object({
+    scores: z.array(scoreInputSchema).length(4),
+  })
+  .refine(
+    (data) => {
+      const scoreIds = data.scores.map((s) => s.scoreId)
+      const uniqueIds = new Set(scoreIds)
+      return uniqueIds.size === 4
+    },
+    {
+      message: 'スコアIDは4つすべて異なる必要があります',
+    },
+  )
+  .refine(
+    (data) => {
+      const total = data.scores.reduce((sum, s) => sum + s.finalScore, 0)
+      return total === 100000
+    },
+    {
+      message: '4人の合計点数は100,000点である必要があります',
+    },
+  )
+
+export type ScoreInput = z.infer<typeof scoreInputSchema>
+export type UpdateTableScoresInput = z.infer<typeof updateTableScoresSchema>

--- a/src/schemas/scores.ts
+++ b/src/schemas/scores.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { TOTAL_SCORE } from '@/src/constants/mahjong'
 
 /**
  * スコア入力データ（単一プレイヤー）
@@ -28,7 +29,7 @@ export const updateTableScoresSchema = z
   .refine(
     (data) => {
       const total = data.scores.reduce((sum, s) => sum + s.finalScore, 0)
-      return total === 100000
+      return total === TOTAL_SCORE
     },
     {
       message: '4人の合計点数は100,000点である必要があります',

--- a/src/server/repositories/scores.ts
+++ b/src/server/repositories/scores.ts
@@ -1,0 +1,60 @@
+import { eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { scoresTable } from '@/db/schema/scores'
+import { tablesTable } from '@/db/schema/tables'
+
+/**
+ * テーブル情報を取得（tableType 含む）
+ */
+export async function findTableById(tableId: string) {
+  const table = await db.query.tablesTable.findFirst({
+    where: eq(tablesTable.id, tableId),
+    columns: {
+      id: true,
+      tableType: true,
+      sessionId: true,
+    },
+  })
+  return table
+}
+
+/**
+ * テーブルの全スコアを取得（wind 含む）
+ */
+export async function findScoresByTableId(tableId: string) {
+  const scores = await db.query.scoresTable.findMany({
+    where: eq(scoresTable.tableId, tableId),
+    columns: {
+      id: true,
+      wind: true,
+      finalScore: true,
+    },
+  })
+  return scores
+}
+
+/**
+ * スコアを更新（finalScore, scorePt, rank, rankPt, totalPt）
+ */
+export async function updateScore(
+  scoreId: string,
+  data: {
+    finalScore: number
+    scorePt: string
+    rank: number
+    rankPt: number
+    totalPt: string
+  },
+) {
+  await db
+    .update(scoresTable)
+    .set({
+      finalScore: data.finalScore,
+      scorePt: data.scorePt,
+      rank: data.rank,
+      rankPt: data.rankPt,
+      totalPt: data.totalPt,
+      updatedAt: new Date(),
+    })
+    .where(eq(scoresTable.id, scoreId))
+}

--- a/src/server/repositories/scores.ts
+++ b/src/server/repositories/scores.ts
@@ -32,29 +32,3 @@ export async function findScoresByTableId(tableId: string) {
   })
   return scores
 }
-
-/**
- * スコアを更新（finalScore, scorePt, rank, rankPt, totalPt）
- */
-export async function updateScore(
-  scoreId: string,
-  data: {
-    finalScore: number
-    scorePt: string
-    rank: number
-    rankPt: number
-    totalPt: string
-  },
-) {
-  await db
-    .update(scoresTable)
-    .set({
-      finalScore: data.finalScore,
-      scorePt: data.scorePt,
-      rank: data.rank,
-      rankPt: data.rankPt,
-      totalPt: data.totalPt,
-      updatedAt: new Date(),
-    })
-    .where(eq(scoresTable.id, scoreId))
-}

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -3,6 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi'
 import { errorHandler } from '../middleware/error-handler'
 import leaguesRoutes from './leagues'
 import playersRoutes from './players'
+import scoresRoutes from './scores'
 import sessionsRoutes from './sessions'
 
 const app = new OpenAPIHono().basePath('/api')
@@ -20,10 +21,12 @@ app.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
 
 // OpenAPIルートを定義
 // ★ playersRoutes と sessionsRoutes は /leagues/:leagueId/* のパスを持つため、/leagues でマウント
+// ★ scoresRoutes は /tables/:tableId/* のパスを持つため、/tables でマウント
 const routes = app
   .route('/leagues', leaguesRoutes)
   .route('/leagues', playersRoutes)
   .route('/leagues', sessionsRoutes)
+  .route('/tables', scoresRoutes)
 
 // ★ RPC用の型をエクスポート（フロントエンドで使用）
 // 注意: ドキュメントルート(/doc, /ui)を追加する前にエクスポートし、純粋なAPIエンドポイントの型のみを提供

--- a/src/server/routes/leagues.ts
+++ b/src/server/routes/leagues.ts
@@ -127,7 +127,7 @@ const getLeagueRoute = createRoute({
 
 app.openapi(getLeagueRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('id')
+  const { id: leagueId } = c.req.valid('param')
   const league = await leaguesService.getLeagueById(leagueId, userId)
   return c.json(league, 200)
 })
@@ -182,7 +182,7 @@ const updateLeagueRoute = createRoute({
 
 app.openapi(updateLeagueRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('id')
+  const { id: leagueId } = c.req.valid('param')
   const data = c.req.valid('json')
   const league = await leaguesService.updateLeague(leagueId, userId, data)
   return c.json(league, 200)
@@ -225,7 +225,7 @@ const deleteLeagueRoute = createRoute({
 
 app.openapi(deleteLeagueRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('id')
+  const { id: leagueId } = c.req.valid('param')
   await leaguesService.deleteLeague(leagueId, userId)
   return c.body(null, 204)
 })
@@ -280,7 +280,7 @@ const updateLeagueStatusRoute = createRoute({
 
 app.openapi(updateLeagueStatusRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('id')
+  const { id: leagueId } = c.req.valid('param')
   const { status } = c.req.valid('json')
   const league = await leaguesService.updateLeagueStatus(leagueId, userId, status)
   return c.json(league, 200)

--- a/src/server/routes/scores.ts
+++ b/src/server/routes/scores.ts
@@ -1,0 +1,71 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import type { AuthContext } from '../middleware/auth'
+import { authMiddleware } from '../middleware/auth'
+import {
+  BadRequestResponse,
+  ForbiddenResponse,
+  NotFoundResponse,
+  UnauthorizedResponse,
+} from '../schemas/common'
+import { UpdateTableScoresRequestSchema } from '../schemas/scores'
+import * as scoresService from '../services/scores'
+
+const app = new OpenAPIHono<AuthContext>()
+
+// Apply auth middleware to all routes
+app.use('*', authMiddleware)
+
+/**
+ * PUT /api/tables/:tableId/scores - Update table scores
+ */
+const updateScoresRoute = createRoute({
+  method: 'put',
+  path: '/{tableId}/scores',
+  tags: ['scores'],
+  summary: 'Update table scores',
+  description:
+    'Update all scores for a table and calculate points automatically. Requires exactly 4 unique scores with a total of 100,000 points. Calculates scorePt, rank (with wind-based tiebreaking), rankPt, and totalPt.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: z.object({
+      tableId: z
+        .string()
+        .uuid()
+        .openapi({
+          param: {
+            name: 'tableId',
+            in: 'path',
+          },
+          example: '123e4567-e89b-12d3-a456-426614174000',
+          description: 'Table ID',
+        }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateTableScoresRequestSchema,
+        },
+      },
+      description: 'Score update request (4 players, total must be 100,000)',
+    },
+  },
+  responses: {
+    204: {
+      description: 'Successfully updated scores',
+    },
+    400: BadRequestResponse,
+    401: UnauthorizedResponse,
+    403: ForbiddenResponse,
+    404: NotFoundResponse,
+  },
+})
+
+app.openapi(updateScoresRoute, async (c) => {
+  const { tableId } = c.req.valid('param')
+  const data = c.req.valid('json')
+
+  await scoresService.updateTableScores(tableId, data)
+  return c.body(null, 204)
+})
+
+export default app

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -71,7 +71,7 @@ const createSessionRoute = createRoute({
 
 app.openapi(createSessionRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('leagueId')
+  const { leagueId } = c.req.valid('param')
   const session = await sessionsService.createSession(leagueId, userId)
   return c.json(session, 201)
 })
@@ -118,7 +118,7 @@ const getSessionsRoute = createRoute({
 
 app.openapi(getSessionsRoute, async (c) => {
   const userId = c.get('userId')
-  const leagueId = c.req.param('leagueId')
+  const { leagueId } = c.req.valid('param')
   const sessions = await sessionsService.getSessionsByLeagueId(leagueId, userId)
   return c.json({ sessions }, 200)
 })

--- a/src/server/schemas/scores.ts
+++ b/src/server/schemas/scores.ts
@@ -1,4 +1,5 @@
 import { z } from '@hono/zod-openapi'
+import { TOTAL_SCORE } from '@/src/constants/mahjong'
 
 /**
  * スコア入力（OpenAPI 用）
@@ -18,7 +19,12 @@ export const ScoreInputSchema = z
 
 /**
  * テーブルスコア更新リクエスト（OpenAPI 用）
- * バリデーションロジックはベーススキーマ（src/schemas/scores.ts）と同じ
+ *
+ * NOTE: バリデーションロジックはベーススキーマ（src/schemas/scores.ts）と同じですが、
+ * zod と @hono/zod-openapi の型互換性がないため、.extend() でインポートすることができません。
+ * そのため、やむを得ずバリデーションロジックを再定義しています。
+ *
+ * 参考: https://github.com/honojs/middleware/issues/174
  */
 export const UpdateTableScoresRequestSchema = z
   .object({
@@ -39,7 +45,7 @@ export const UpdateTableScoresRequestSchema = z
   .refine(
     (data) => {
       const total = data.scores.reduce((sum, s) => sum + s.finalScore, 0)
-      return total === 100000
+      return total === TOTAL_SCORE
     },
     {
       message: '4人の合計点数は100,000点である必要があります',

--- a/src/server/schemas/scores.ts
+++ b/src/server/schemas/scores.ts
@@ -18,6 +18,7 @@ export const ScoreInputSchema = z
 
 /**
  * テーブルスコア更新リクエスト（OpenAPI 用）
+ * バリデーションロジックはベーススキーマ（src/schemas/scores.ts）と同じ
  */
 export const UpdateTableScoresRequestSchema = z
   .object({

--- a/src/server/schemas/scores.ts
+++ b/src/server/schemas/scores.ts
@@ -1,0 +1,47 @@
+import { z } from '@hono/zod-openapi'
+
+/**
+ * スコア入力（OpenAPI 用）
+ */
+export const ScoreInputSchema = z
+  .object({
+    scoreId: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174001',
+      description: 'Score ID',
+    }),
+    finalScore: z.number().int().min(0).max(200000).openapi({
+      example: 25600,
+      description: 'Final score (0-200,000)',
+    }),
+  })
+  .openapi('ScoreInput')
+
+/**
+ * テーブルスコア更新リクエスト（OpenAPI 用）
+ */
+export const UpdateTableScoresRequestSchema = z
+  .object({
+    scores: z.array(ScoreInputSchema).length(4).openapi({
+      description: '4人分のスコア（合計100,000点、すべて異なるscoreID）',
+    }),
+  })
+  .refine(
+    (data) => {
+      const scoreIds = data.scores.map((s) => s.scoreId)
+      const uniqueIds = new Set(scoreIds)
+      return uniqueIds.size === 4
+    },
+    {
+      message: 'スコアIDは4つすべて異なる必要があります',
+    },
+  )
+  .refine(
+    (data) => {
+      const total = data.scores.reduce((sum, s) => sum + s.finalScore, 0)
+      return total === 100000
+    },
+    {
+      message: '4人の合計点数は100,000点である必要があります',
+    },
+  )
+  .openapi('UpdateTableScoresRequest')

--- a/src/server/services/scores.ts
+++ b/src/server/services/scores.ts
@@ -1,0 +1,121 @@
+import type { UpdateTableScoresInput } from '@/src/schemas/scores'
+import type { Wind } from '@/src/schemas/sessions'
+import { BadRequestError } from '../middleware/error-handler'
+import * as scoresRepository from '../repositories/scores'
+
+/**
+ * 座順の優先度（同点時のタイブレーク用）
+ */
+const WIND_PRIORITY: Record<Wind, number> = {
+  east: 0,
+  south: 1,
+  west: 2,
+  north: 3,
+}
+
+/**
+ * テーブルタイプ別の順位ポイント配点
+ */
+const RANK_POINTS: Record<string, number[]> = {
+  first: [40, 30, 20, 10],
+  upper: [80, 70, 40, 30],
+  lower: [60, 50, 20, 10],
+}
+
+/**
+ * 点数ポイント計算
+ */
+export function calculateScorePt(finalScore: number): number {
+  return (finalScore - 25000) / 1000
+}
+
+/**
+ * 順位判定（同点時は座順優先）
+ */
+export function calculateRanks(
+  scores: Array<{ scoreId: string; finalScore: number; wind: Wind }>,
+): Map<string, number> {
+  const sorted = [...scores].sort((a, b) => {
+    // 点数で降順ソート
+    if (b.finalScore !== a.finalScore) {
+      return b.finalScore - a.finalScore
+    }
+    // 同点時は座順優先（東 > 南 > 西 > 北）
+    return WIND_PRIORITY[a.wind] - WIND_PRIORITY[b.wind]
+  })
+
+  const rankMap = new Map<string, number>()
+  sorted.forEach((score, index) => {
+    rankMap.set(score.scoreId, index + 1) // 1位, 2位, 3位, 4位
+  })
+
+  return rankMap
+}
+
+/**
+ * 順位ポイント計算
+ */
+export function calculateRankPt(rank: number, tableType: string): number {
+  const points = RANK_POINTS[tableType]
+  if (!points) {
+    throw new BadRequestError(`不正なテーブルタイプです: ${tableType}`)
+  }
+  return points[rank - 1] // rank は 1-indexed、配列は 0-indexed
+}
+
+/**
+ * 合計ポイント計算
+ */
+export function calculateTotalPt(rankPt: number, scorePt: number): number {
+  return rankPt + scorePt
+}
+
+/**
+ * テーブルスコア一括更新
+ */
+export async function updateTableScores(tableId: string, input: UpdateTableScoresInput) {
+  // 1. テーブル情報取得（tableType 必要）
+  const table = await scoresRepository.findTableById(tableId)
+  if (!table) {
+    throw new BadRequestError('テーブルが見つかりません')
+  }
+
+  // 2. 既存スコア取得（wind 情報必要）
+  const existingScores = await scoresRepository.findScoresByTableId(tableId)
+  const windMap = new Map(existingScores.map((s) => [s.id, s.wind]))
+
+  // 3. 順位計算
+  const scoresWithWind = input.scores.map((s) => {
+    const wind = windMap.get(s.scoreId)
+    if (!wind) {
+      throw new BadRequestError(`スコアIDが見つかりません: ${s.scoreId}`)
+    }
+    return {
+      scoreId: s.scoreId,
+      finalScore: s.finalScore,
+      wind,
+    }
+  })
+  const ranks = calculateRanks(scoresWithWind)
+
+  // 4. 各スコアを計算・更新
+  for (const scoreInput of input.scores) {
+    const finalScore = scoreInput.finalScore
+    const rank = ranks.get(scoreInput.scoreId)
+    if (rank === undefined) {
+      throw new BadRequestError(`順位の計算に失敗しました: ${scoreInput.scoreId}`)
+    }
+
+    const scorePt = calculateScorePt(finalScore)
+    const rankPt = calculateRankPt(rank, table.tableType)
+    const totalPt = calculateTotalPt(rankPt, scorePt)
+
+    await scoresRepository.updateScore(scoreInput.scoreId, {
+      finalScore,
+      scorePt: scorePt.toFixed(1), // 小数点1桁
+      rank,
+      rankPt,
+      totalPt: totalPt.toFixed(1), // 小数点1桁
+    })
+  }
+}


### PR DESCRIPTION
## 概要
麻雀の対局結果（スコア）を入力し、自動計算（素点・順位点・合計ポイント）を行って保存する機能を実装しました。
これにより、各節の卓ごとに成績を記録できるようになります。

## 変更点

- **feat(api)**: スコア入力・更新API (`PUT /api/tables/:id/scores`) の実装
    - 素点計算 (`(score - 25000) / 1000`)、順位判定（同点時座順優先）、ウマ・オカ加算ロジックの実装
- **feat(ui)**: スコア入力ダイアログ (`score-input-dialog.tsx`) の実装
    - 4人分の点数入力とリアルタイムの合計点バリデーション (100,000点)
- **feat(ui)**: セッションリストへの「スコア入力」ボタン追加と統合
- **feat(hooks)**: スコア更新用フック (`useUpdateScores`) の実装
- **docs**: 関連するドキュメントの整備とアーカイブ整理

## 関連Issue

Closes #58
